### PR TITLE
refactor: Replace admin custom claim with facility-level admins array

### DIFF
--- a/apps/admin-react/app/context/auth-context.tsx
+++ b/apps/admin-react/app/context/auth-context.tsx
@@ -1,39 +1,30 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import { onAuthStateChanged, type User } from 'firebase/auth';
 import { auth } from '../firebase';
-import { Role } from '@models/user';
 import { usePermissionsStore } from '../stores/permissions.store';
 import { useSessionStore } from '../stores/session.store';
 
 interface AuthContextValue {
   user: User | null;
   loading: boolean;
-  isAdmin: boolean;
 }
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
   loading: true,
-  isAdmin: false,
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const [isAdmin, setIsAdmin] = useState(false);
   const { resetPermissions } = usePermissionsStore();
   const { resetSession } = useSessionStore();
 
   useEffect(() => {
     return onAuthStateChanged(auth, async (firebaseUser) => {
-      if (firebaseUser) {
-        const tokenResult = await firebaseUser.getIdTokenResult();
-        const roles = (tokenResult.claims['roles'] as string[]) ?? [];
-        setIsAdmin(roles.includes(Role.ADMIN));
-      } else {
+      if (!firebaseUser) {
         resetPermissions();
         resetSession();
-        setIsAdmin(false);
       }
       setUser(firebaseUser);
       setLoading(false);
@@ -41,7 +32,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, loading, isAdmin }}>
+    <AuthContext.Provider value={{ user, loading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/apps/admin-react/app/routes/home/employees/employees-create.tsx
+++ b/apps/admin-react/app/routes/home/employees/employees-create.tsx
@@ -22,9 +22,10 @@ import { createEmployee } from '@front/employees';
 import { getAllRoles } from '@front/roles';
 import type { Role as RoleModel } from '@models/permissions';
 import { PermissionSection, PermissionAction } from '@models/permissions';
-import { db, functions } from '../../../firebase';
+import { auth, db, functions } from '../../../firebase';
 import { useSessionStore } from '../../../stores/session.store';
 import { PermissionGuard } from '../../../components/permission-guard';
+import { sendPasswordResetEmail } from 'firebase/auth';
 
 const employeeCreateSchema = z.object({
   name: z.string().min(1, 'Nombre requerido').max(50, 'Maximo 50 caracteres'),
@@ -72,6 +73,7 @@ export default function EmployeesCreatePage() {
         facilityId: selectedFacility.id,
       });
       sileo.success({ title: 'Empleado creado correctamente', duration: 3000 });
+      await sendPasswordResetEmail(auth, data.email);
       navigate('/home/employees');
     } catch (error: unknown) {
       const message =

--- a/apps/admin-react/app/routes/home/employees/employees-create.tsx
+++ b/apps/admin-react/app/routes/home/employees/employees-create.tsx
@@ -10,6 +10,7 @@ import { Button } from '@front/cn/components/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@front/cn/components/card';
 import { Input } from '@front/cn/components/input';
 import { Label } from '@front/cn/components/label';
+import { Checkbox } from '@front/cn/components/checkbox';
 import {
   Select,
   SelectContent,
@@ -20,7 +21,6 @@ import {
 import { createEmployee } from '@front/employees';
 import { getAllRoles } from '@front/roles';
 import type { Role as RoleModel } from '@models/permissions';
-import { Role } from '@models/user';
 import { PermissionSection, PermissionAction } from '@models/permissions';
 import { db, functions } from '../../../firebase';
 import { useSessionStore } from '../../../stores/session.store';
@@ -33,17 +33,10 @@ const employeeCreateSchema = z.object({
     .min(1, 'Email requerido')
     .pipe(z.email({ error: 'Email invalido' })),
   roleId: z.string().min(1, 'Rol requerido'),
-  userType: z.enum([Role.ADMIN, Role.EMPLOYEE], {
-    error: 'Tipo de usuario requerido',
-  }),
+  isAdmin: z.boolean(),
 });
 
 type EmployeeCreateFormValues = z.infer<typeof employeeCreateSchema>;
-
-const USER_TYPE_LABELS: Record<string, string> = {
-  [Role.ADMIN]: 'Administrador',
-  [Role.EMPLOYEE]: 'Empleado',
-};
 
 export default function EmployeesCreatePage() {
   const navigate = useNavigate();
@@ -61,7 +54,7 @@ export default function EmployeesCreatePage() {
       name: '',
       email: '',
       roleId: '',
-      userType: undefined,
+      isAdmin: false,
     },
   });
 
@@ -169,31 +162,19 @@ export default function EmployeesCreatePage() {
               )}
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="userType">Tipo de usuario</Label>
+            <div className="flex items-center gap-2 pt-6">
               <Controller
-                name="userType"
+                name="isAdmin"
                 control={control}
                 render={({ field }) => (
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <SelectTrigger id="userType" aria-invalid={!!errors.userType} className="w-full">
-                      <SelectValue placeholder="Seleccionar tipo" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {[Role.ADMIN, Role.EMPLOYEE].map((type) => (
-                        <SelectItem key={type} value={type}>
-                          {USER_TYPE_LABELS[type]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Checkbox
+                    id="isAdmin"
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
                 )}
               />
-              {errors.userType && (
-                <p className="text-sm text-destructive">
-                  {errors.userType.message}
-                </p>
-              )}
+              <Label htmlFor="isAdmin">Es administrador de esta sede</Label>
             </div>
           </CardContent>
         </Card>

--- a/apps/admin-react/app/routes/protected-layout.tsx
+++ b/apps/admin-react/app/routes/protected-layout.tsx
@@ -1,29 +1,35 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Navigate, Outlet } from 'react-router';
 import { Loader2 } from 'lucide-react';
 import { useAuth } from '../context/auth-context';
 import { useSessionStore } from '../stores/session.store';
 import { usePermissionsStore } from '../stores/permissions.store';
 import { db } from '../firebase';
+import { Role } from '@models/user';
 
 export default function ProtectedLayout() {
-  const { user, loading: authLoading, isAdmin } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const { loading: sessionLoading, loadFacilities } = useSessionStore();
-  const facilityId = useSessionStore((s) => s.selectedFacility?.id);
+  const selectedFacility = useSessionStore((s) => s.selectedFacility);
   const currentEmployee = useSessionStore((s) => s.currentEmployee);
   const { loading: permissionsLoading, loadPermissions, permissions } = usePermissionsStore();
+  const [isSuperAdmin, setIsSuperAdmin] = useState(false);
 
   useEffect(() => {
     if (user) {
       loadFacilities(user.uid);
+      user.getIdTokenResult().then((tokenResult) => {
+        const roles = (tokenResult.claims['roles'] as string[]) ?? [];
+        setIsSuperAdmin(roles.includes(Role.SUPER_ADMIN));
+      });
     }
   }, [user, loadFacilities]);
 
   useEffect(() => {
-    if (facilityId && currentEmployee) {
-      loadPermissions(db, facilityId, currentEmployee, isAdmin);
+    if (selectedFacility && currentEmployee) {
+      loadPermissions(db, selectedFacility, currentEmployee, isSuperAdmin);
     }
-  }, [facilityId, currentEmployee, isAdmin, loadPermissions]);
+  }, [selectedFacility, currentEmployee, isSuperAdmin, loadPermissions]);
 
   if (authLoading || sessionLoading || permissionsLoading || !permissions) {
     return (

--- a/apps/admin-react/app/routes/protected-layout.tsx
+++ b/apps/admin-react/app/routes/protected-layout.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Navigate, Outlet } from 'react-router';
 import { Loader2 } from 'lucide-react';
 import { useAuth } from '../context/auth-context';
 import { useSessionStore } from '../stores/session.store';
 import { usePermissionsStore } from '../stores/permissions.store';
 import { db } from '../firebase';
-import { Role } from '@models/user';
 
 export default function ProtectedLayout() {
   const { user, loading: authLoading } = useAuth();
@@ -13,23 +12,18 @@ export default function ProtectedLayout() {
   const selectedFacility = useSessionStore((s) => s.selectedFacility);
   const currentEmployee = useSessionStore((s) => s.currentEmployee);
   const { loading: permissionsLoading, loadPermissions, permissions } = usePermissionsStore();
-  const [isSuperAdmin, setIsSuperAdmin] = useState(false);
 
   useEffect(() => {
     if (user) {
       loadFacilities(user.uid);
-      user.getIdTokenResult().then((tokenResult) => {
-        const roles = (tokenResult.claims['roles'] as string[]) ?? [];
-        setIsSuperAdmin(roles.includes(Role.SUPER_ADMIN));
-      });
     }
   }, [user, loadFacilities]);
 
   useEffect(() => {
     if (selectedFacility && currentEmployee) {
-      loadPermissions(db, selectedFacility, currentEmployee, isSuperAdmin);
+      loadPermissions(db, selectedFacility, currentEmployee);
     }
-  }, [selectedFacility, currentEmployee, isSuperAdmin, loadPermissions]);
+  }, [selectedFacility, currentEmployee, loadPermissions]);
 
   if (authLoading || sessionLoading || permissionsLoading || !permissions) {
     return (

--- a/apps/admin-react/app/routes/protected-layout.tsx
+++ b/apps/admin-react/app/routes/protected-layout.tsx
@@ -8,10 +8,10 @@ import { db } from '../firebase';
 
 export default function ProtectedLayout() {
   const { user, loading: authLoading } = useAuth();
-  const { loading: sessionLoading, loadFacilities } = useSessionStore();
+  const { loadFacilities, completed: sessionCompleted } = useSessionStore();
   const selectedFacility = useSessionStore((s) => s.selectedFacility);
   const currentEmployee = useSessionStore((s) => s.currentEmployee);
-  const { loading: permissionsLoading, loadPermissions, permissions } = usePermissionsStore();
+  const { loadPermissions, completed: permissionsCompleted } = usePermissionsStore();
 
   useEffect(() => {
     if (user) {
@@ -25,7 +25,7 @@ export default function ProtectedLayout() {
     }
   }, [selectedFacility, currentEmployee, loadPermissions]);
 
-  if (authLoading || sessionLoading || permissionsLoading || !permissions) {
+  if (authLoading || !sessionCompleted || !permissionsCompleted) {
     return (
       <div className="flex h-screen items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/apps/admin-react/app/stores/permissions.store.ts
+++ b/apps/admin-react/app/stores/permissions.store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import type { Firestore } from 'firebase/firestore';
-import type { EmployeeModel } from '@models/facility';
+import type { EmployeeModel, FacilityModel } from '@models/facility';
 import { type PermissionsBySection, PermissionSection, PermissionAction } from '@models/permissions';
 import { getRoleById } from '@front/roles';
 
@@ -9,7 +9,7 @@ interface PermissionsState {
   isAdmin: boolean;
   loading: boolean;
 
-  loadPermissions: (db: Firestore, facilityId: string, employee: EmployeeModel, isSuperAdmin: boolean) => Promise<void>;
+  loadPermissions: (db: Firestore, facility: FacilityModel, employee: EmployeeModel, isSuperAdmin: boolean) => Promise<void>;
   hasPermission: (section: PermissionSection, action: PermissionAction) => boolean;
   hasSectionAccess: (section: PermissionSection) => boolean;
   resetPermissions: () => void;
@@ -20,10 +20,12 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   isAdmin: false,
   loading: false,
 
-  loadPermissions: async (db, facilityId, employee, isSuperAdmin) => {
+  loadPermissions: async (db, facility, employee, isSuperAdmin) => {
     set({ loading: true });
 
-    if (isSuperAdmin || employee.isAdmin) {
+    const isFacilityAdmin = facility.admins?.includes(employee.uid) ?? false;
+
+    if (isSuperAdmin || isFacilityAdmin) {
       set({ isAdmin: true, permissions: {}, loading: false });
       return;
     }
@@ -34,7 +36,7 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
     }
 
     try {
-      const role = await getRoleById(db, facilityId, employee.roleId);
+      const role = await getRoleById(db, facility.id as string, employee.roleId);
       set({
         isAdmin: false,
         permissions: role?.permissions ?? {},

--- a/apps/admin-react/app/stores/permissions.store.ts
+++ b/apps/admin-react/app/stores/permissions.store.ts
@@ -8,7 +8,8 @@ interface PermissionsState {
   permissions: PermissionsBySection | null;
   isAdmin: boolean;
   loading: boolean;
-
+  completed: boolean;
+  error: unknown | null;
   loadPermissions: (db: Firestore, facility: FacilityModel, employee: EmployeeModel) => Promise<void>;
   hasPermission: (section: PermissionSection, action: PermissionAction) => boolean;
   hasSectionAccess: (section: PermissionSection) => boolean;
@@ -19,19 +20,20 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   permissions: null,
   isAdmin: false,
   loading: false,
-
+  completed: false,
+  error: null,
   loadPermissions: async (db, facility, employee) => {
     set({ loading: true });
 
     const isFacilityAdmin = facility.admins?.includes(employee.uid) ?? false;
 
     if (isFacilityAdmin) {
-      set({ isAdmin: true, permissions: {}, loading: false });
+      set({ isAdmin: true, permissions: {}, loading: false, completed: true });
       return;
     }
 
     if (!employee.roleId) {
-      set({ isAdmin: false, permissions: {}, loading: false });
+      set({ isAdmin: false, permissions: {}, loading: false, completed: true });
       return;
     }
 
@@ -41,9 +43,11 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
         isAdmin: false,
         permissions: role?.permissions ?? {},
         loading: false,
+        completed: true,
       });
-    } catch {
-      set({ isAdmin: false, permissions: {}, loading: false });
+    } catch(error) {
+      console.error('Error loading permissions:', error);
+      set({ isAdmin: false, permissions: {}, loading: false, completed: true, error: error });
     }
   },
 
@@ -60,6 +64,6 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   },
 
   resetPermissions: () => {
-    set({ permissions: null, isAdmin: false, loading: false });
+    set({ permissions: null, isAdmin: false, loading: false, completed: false, error: null });
   },
 }));

--- a/apps/admin-react/app/stores/permissions.store.ts
+++ b/apps/admin-react/app/stores/permissions.store.ts
@@ -9,7 +9,7 @@ interface PermissionsState {
   isAdmin: boolean;
   loading: boolean;
 
-  loadPermissions: (db: Firestore, facility: FacilityModel, employee: EmployeeModel, isSuperAdmin: boolean) => Promise<void>;
+  loadPermissions: (db: Firestore, facility: FacilityModel, employee: EmployeeModel) => Promise<void>;
   hasPermission: (section: PermissionSection, action: PermissionAction) => boolean;
   hasSectionAccess: (section: PermissionSection) => boolean;
   resetPermissions: () => void;
@@ -20,12 +20,12 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   isAdmin: false,
   loading: false,
 
-  loadPermissions: async (db, facility, employee, isSuperAdmin) => {
+  loadPermissions: async (db, facility, employee) => {
     set({ loading: true });
 
     const isFacilityAdmin = facility.admins?.includes(employee.uid) ?? false;
 
-    if (isSuperAdmin || isFacilityAdmin) {
+    if (isFacilityAdmin) {
       set({ isAdmin: true, permissions: {}, loading: false });
       return;
     }

--- a/apps/admin-react/app/stores/session.store.ts
+++ b/apps/admin-react/app/stores/session.store.ts
@@ -9,6 +9,7 @@ interface SessionState {
   selectedFacility: FacilityModel | null;
   currentEmployee: EmployeeModel | null;
   loading: boolean;
+  completed: boolean;
   error: string | null;
   loadFacilities: (userId: string) => Promise<void>;
   setSelectedFacility: (facility: FacilityModel, userId: string) => Promise<void>;
@@ -21,6 +22,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   currentEmployee: null,
   loading: false,
   error: null,
+  completed: false,
 
   loadFacilities: async (userId: string) => {
     if (get().facilities.length > 0) return;
@@ -40,11 +42,14 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         selectedFacility,
         currentEmployee,
         loading: false,
+        completed: true,
       });
     } catch (error) {
+      console.error('Error loading facilities:', error);
       set({
         loading: false,
         error: 'Failed to load facilities',
+        completed: true,
       });
     }
   },
@@ -56,6 +61,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   },
 
   resetSession: () => {
-    set({ facilities: [], selectedFacility: null, currentEmployee: null, loading: false, error: null });
+    set({ facilities: [], selectedFacility: null, currentEmployee: null, loading: false, error: null, completed: false });
   },
 }));

--- a/apps/functions/src/auth/create-user.function.ts
+++ b/apps/functions/src/auth/create-user.function.ts
@@ -62,7 +62,7 @@ export const createUser = onRequest(async (request, response) => {
         emailVerified: false,
       });
 
-      auth.setCustomUserClaims(userRecord.uid, { roles: [Role.ADMIN] });
+      auth.setCustomUserClaims(userRecord.uid, { roles: [Role.EMPLOYEE] });
 
       // Create profile document in Firestore
       const profileData = {

--- a/apps/functions/src/auth/setup-admin-structure.function.ts
+++ b/apps/functions/src/auth/setup-admin-structure.function.ts
@@ -36,38 +36,34 @@ export const setupAdminStructure = onRequest(async (request, response) => {
     const db = getFirestore();
 
     try {
-      // 1. Create Super Admin
       const superAdmin = await _createUser('Super Admin', Role.SUPER_ADMIN);
 
-      // 2. Create Facility
+      const facilityAdmin = await _createUser('Facility Admin', Role.EMPLOYEE);
+
       const facilityRef = db.collection('facilities').doc();
       const facility: Omit<FacilityModel, 'createdAt'> & { createdAt: FieldValue } = {
         createdAt: FieldValue.serverTimestamp(),
         name: 'Norseus Gym',
         logo: 'https://via.placeholder.com/150',
         logoIcon: null,
+        admins: [facilityAdmin.uid],
       };
       await facilityRef.set(facility);
 
-      // 3. Create Facility Admin
-      const facilityAdmin = await _createUser('Facility Admin', Role.ADMIN);
       const adminEmployee: Omit<EmployeeModel, 'joined'> & { joined: FieldValue } = {
         uid: facilityAdmin.uid,
         joined: FieldValue.serverTimestamp(),
-        roleId: null, // Assign a role if you have a roles collection
-        isAdmin: true,
+        roleId: null,
         profile: (await db.collection('profiles').doc(facilityAdmin.uid).get()).data() as ProfileModel,
         isActive: true,
       };
       await facilityRef.collection('employees').doc(facilityAdmin.uid).set(adminEmployee);
 
-      // 4. Create Facility Employer
-      const facilityEmployer = await _createUser('Facility Employer', Role.USER);
+      const facilityEmployer = await _createUser('Facility Employer', Role.EMPLOYEE);
       const employerEmployee: Omit<EmployeeModel, 'joined'> & { joined: FieldValue } = {
         uid: facilityEmployer.uid,
         joined: FieldValue.serverTimestamp(),
-        roleId: null, // Assign a role if you have a roles collection
-        isAdmin: false,
+        roleId: null,
         isActive: true,
         profile: (await db.collection('profiles').doc(facilityEmployer.uid).get()).data() as ProfileModel,
       };

--- a/apps/functions/src/clients/create-client.function.ts
+++ b/apps/functions/src/clients/create-client.function.ts
@@ -1,7 +1,7 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getAuth, FirebaseAuthError } from 'firebase-admin/auth';
 import { getFirestore, Timestamp } from 'firebase-admin/firestore';
-import { CLIENT_COLLECTION, FACILITY_COLLECTION, EMPLOYEE_COLLECTION, ClientModel, EmployeeModel } from '@models/facility';
+import { CLIENT_COLLECTION, FACILITY_COLLECTION, ClientModel } from '@models/facility';
 import {
   CreateClientRequest,
   CreateClientResponse,
@@ -56,35 +56,16 @@ export const createClient = onCall(async (request): Promise<CreateClientResponse
   const auth = getAuth();
   const currentUserId = request.auth.uid;
 
-  // 3. Check if user is facility admin (bypass permission check for admins)
-  const employeeRef = db
-    .collection(FACILITY_COLLECTION)
-    .doc(data.facilityId)
-    .collection(EMPLOYEE_COLLECTION)
-    .doc(currentUserId);
+  const hasPermission = await checkUserPermission(
+    db,
+    data.facilityId,
+    currentUserId,
+    PermissionSection.CLIENTS,
+    PermissionAction.CREATE,
+  );
 
-  const employeeDoc = await employeeRef.get();
-
-  if (!employeeDoc.exists) {
-    throw new HttpsError('permission-denied', 'You are not an employee of this facility');
-  }
-
-  const employeeData = employeeDoc.data() as EmployeeModel;
-
-  // Facility admins have full access - skip permission check
-  if (!employeeData.isAdmin) {
-    // Non-admins need explicit CLIENTS.CREATE permission
-    const hasPermission = await checkUserPermission(
-      db,
-      data.facilityId,
-      currentUserId,
-      PermissionSection.CLIENTS,
-      PermissionAction.CREATE,
-    );
-
-    if (!hasPermission) {
-      throw new HttpsError('permission-denied', 'You do not have permission to create clients');
-    }
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'You do not have permission to create clients');
   }
 
   try {

--- a/apps/functions/src/employees/create-employee.function.ts
+++ b/apps/functions/src/employees/create-employee.function.ts
@@ -91,7 +91,8 @@ export const createEmployee = onCall(async (request) => {
         .update({ admins: FieldValue.arrayUnion(userRecord.uid) });
     }
 
-    auth.generatePasswordResetLink(data.email);
+    const passwordResetLink = await auth.generatePasswordResetLink(data.email);
+    console.log('Password reset link:', passwordResetLink);
 
     return { success: true, userId: userRecord.uid };
   } catch (error) {

--- a/apps/functions/src/employees/create-employee.function.ts
+++ b/apps/functions/src/employees/create-employee.function.ts
@@ -1,6 +1,6 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getAuth, FirebaseAuthError } from 'firebase-admin/auth';
-import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { getFirestore, Timestamp, FieldValue } from 'firebase-admin/firestore';
 import { CreateEmployeeRequest, EMPLOYEE_COLLECTION, EmployeeModel, FACILITY_COLLECTION } from '@models/facility';
 import { PROFILE_COLLECTION, ProfileModel, Role } from '@models/user';
 import { PermissionSection, PermissionAction } from '@models/permissions';
@@ -21,7 +21,7 @@ const CreateEmployeeSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name too long'),
   roleId: z.string().min(1, 'Role ID is required'),
   facilityId: z.string().min(1, 'Facility ID is required'),
-  userType: z.enum([Role.ADMIN, Role.EMPLOYEE]),
+  isAdmin: z.boolean().default(false),
 });
 
 export const createEmployee = onCall(async (request) => {
@@ -58,7 +58,7 @@ export const createEmployee = onCall(async (request) => {
       emailVerified: false,
     });
 
-    await auth.setCustomUserClaims(userRecord.uid, { roles: [data.userType] });
+    await auth.setCustomUserClaims(userRecord.uid, { roles: [Role.EMPLOYEE] });
     const timestamp = Timestamp.fromDate(new Date());
 
     const profileData: ProfileModelForAdmin = {
@@ -74,7 +74,6 @@ export const createEmployee = onCall(async (request) => {
       uid: userRecord.uid,
       joined: timestamp,
       roleId: data.roleId,
-      isAdmin: data.userType === Role.ADMIN,
       isActive: true,
       profile: profileData,
     };
@@ -84,6 +83,13 @@ export const createEmployee = onCall(async (request) => {
       .collection(EMPLOYEE_COLLECTION)
       .doc(userRecord.uid)
       .set(employeeData);
+
+    if (data.isAdmin) {
+      await db
+        .collection(FACILITY_COLLECTION)
+        .doc(data.facilityId)
+        .update({ admins: FieldValue.arrayUnion(userRecord.uid) });
+    }
 
     auth.generatePasswordResetLink(data.email);
 

--- a/apps/functions/src/subscriptions/create-subscription.function.ts
+++ b/apps/functions/src/subscriptions/create-subscription.function.ts
@@ -1,6 +1,6 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, Timestamp } from 'firebase-admin/firestore';
-import { FACILITY_COLLECTION, CLIENT_COLLECTION, EMPLOYEE_COLLECTION, EmployeeModel } from '@models/facility';
+import { FACILITY_COLLECTION, CLIENT_COLLECTION } from '@models/facility';
 import { PLANS_COLLECTION, Plan, PlanDuration, PlanDurationDays } from '@models/plans';
 import {
   SUBSCRIPTION_COLLECTION,
@@ -49,32 +49,19 @@ export const createSubscription = onCall(
     const currentUserId = request.auth.uid;
     const facilityRef = db.collection(FACILITY_COLLECTION).doc(data.facilityId);
 
-    const employeeRef = facilityRef
-      .collection(EMPLOYEE_COLLECTION)
-      .doc(currentUserId);
-    const employeeDoc = await employeeRef.get();
+    const hasPermission = await checkUserPermission(
+      db,
+      data.facilityId,
+      currentUserId,
+      PermissionSection.CLIENTS,
+      PermissionAction.UPDATE,
+    );
 
-    if (!employeeDoc.exists) {
-      throw new HttpsError('permission-denied', 'You are not an employee of this facility');
-    }
-
-    const employeeData = employeeDoc.data() as EmployeeModel;
-
-    if (!employeeData.isAdmin) {
-      const hasPermission = await checkUserPermission(
-        db,
-        data.facilityId,
-        currentUserId,
-        PermissionSection.CLIENTS,
-        PermissionAction.UPDATE,
+    if (!hasPermission) {
+      throw new HttpsError(
+        'permission-denied',
+        'You do not have permission to assign plans to clients'
       );
-
-      if (!hasPermission) {
-        throw new HttpsError(
-          'permission-denied',
-          'You do not have permission to assign plans to clients'
-        );
-      }
     }
 
     try {

--- a/apps/functions/src/super-admin/create-facility.function.ts
+++ b/apps/functions/src/super-admin/create-facility.function.ts
@@ -39,7 +39,7 @@ export const createFacilityWithAdmin = onCall(async (request) => {
       displayName: adminName,
       emailVerified: false,
     });
-    await auth.setCustomUserClaims(userRecord.uid, { roles: [Role.ADMIN] });
+    await auth.setCustomUserClaims(userRecord.uid, { roles: [Role.EMPLOYEE] });
 
     // 2. Create profile
     const profileData = {
@@ -57,6 +57,7 @@ export const createFacilityWithAdmin = onCall(async (request) => {
       name: facilityName,
       logo: null,
       logoIcon: null,
+      admins: [userRecord.uid],
     });
 
     // 4. Create employee (admin) in facility
@@ -64,7 +65,6 @@ export const createFacilityWithAdmin = onCall(async (request) => {
       uid: userRecord.uid,
       joined: timestamp,
       roleId: null,
-      isAdmin: true,
       isActive: true,
       profile: profileData,
     });

--- a/apps/functions/src/utilities/permissions.ts
+++ b/apps/functions/src/utilities/permissions.ts
@@ -1,15 +1,33 @@
 import { EMPLOYEE_COLLECTION, FACILITY_COLLECTION, ROLE_COLLECTION } from '@models/facility';
-import { EmployeeModel } from '@models/facility';
+import { EmployeeModel, FacilityModel } from '@models/facility';
 import { PermissionSection, PermissionAction } from '@models/permissions';
 
 /**
+ * Check if the user is a facility admin by checking the facility's admins array
+ */
+export async function isFacilityAdminCheck(
+  db: FirebaseFirestore.Firestore,
+  facilityId: string,
+  userId: string,
+): Promise<boolean> {
+  try {
+    const facilityRef = db.collection(FACILITY_COLLECTION).doc(facilityId);
+    const facilityDoc = await facilityRef.get();
+
+    if (!facilityDoc.exists) {
+      return false;
+    }
+
+    const facilityData = facilityDoc.data() as FacilityModel;
+    return facilityData.admins?.includes(userId) ?? false;
+  } catch (error) {
+    console.error('Error checking facility admin:', error);
+    return false;
+  }
+}
+
+/**
  * Check if the user has a specific permission in a facility
- * @param db Firestore database instance
- * @param facilityId ID of the facility
- * @param userId ID of the user to check permissions for
- * @param section Permission section (e.g., 'employees', 'roles')
- * @param permission Permission action (e.g., 'create', 'read', 'update', 'delete')
- * @returns Promise<boolean> - true if user has permission, false otherwise
  */
 export async function checkUserPermission(
   db: FirebaseFirestore.Firestore,
@@ -19,7 +37,11 @@ export async function checkUserPermission(
   permission: PermissionAction,
 ): Promise<boolean> {
   try {
-    // Get user's employee document
+    const isAdmin = await isFacilityAdminCheck(db, facilityId, userId);
+    if (isAdmin) {
+      return true;
+    }
+
     const employeeRef = db
       .collection(FACILITY_COLLECTION)
       .doc(facilityId)
@@ -34,17 +56,10 @@ export async function checkUserPermission(
 
     const employeeData = employeeDoc.data() as EmployeeModel;
 
-    // If user is facility admin, they have all permissions
-    if (employeeData.isAdmin) {
-      return true;
-    }
-
-    // If user has no role assigned, they can't have specific permissions
     if (!employeeData.roleId) {
       return false;
     }
 
-    // Get user's role document
     const roleRef = db
       .collection(FACILITY_COLLECTION)
       .doc(facilityId)
@@ -59,12 +74,10 @@ export async function checkUserPermission(
 
     const roleData = roleDoc.data();
 
-    // Check if role has permissions for the specified section
     if (!roleData?.permissions || !roleData.permissions[section]) {
       return false;
     }
 
-    // Check if role has the specific permission for the section
     const sectionPermissions = roleData.permissions[section];
     return sectionPermissions.includes(permission);
 
@@ -74,14 +87,8 @@ export async function checkUserPermission(
   }
 }
 
-
-
 /**
  * Check if the user is an employee of the facility
- * @param db Firestore database instance
- * @param facilityId ID of the facility
- * @param userId ID of the user to check
- * @returns Promise<boolean> - true if user is facility employee, false otherwise
  */
 export async function isFacilityEmployee(
   db: FirebaseFirestore.Firestore,

--- a/apps/functions/src/utilities/permissions.ts
+++ b/apps/functions/src/utilities/permissions.ts
@@ -4,6 +4,10 @@ import { PermissionSection, PermissionAction } from '@models/permissions';
 
 /**
  * Check if the user is a facility admin by checking the facility's admins array
+ * @param db Firestore database instance
+ * @param facilityId ID of the facility
+ * @param userId ID of the user to check
+ * @returns Promise<boolean> - true if user is a facility admin, false otherwise
  */
 export async function isFacilityAdminCheck(
   db: FirebaseFirestore.Firestore,
@@ -28,6 +32,12 @@ export async function isFacilityAdminCheck(
 
 /**
  * Check if the user has a specific permission in a facility
+ * @param db Firestore database instance
+ * @param facilityId ID of the facility
+ * @param userId ID of the user to check permissions for
+ * @param section Permission section (e.g., 'employees', 'roles')
+ * @param permission Permission action (e.g., 'create', 'read', 'update', 'delete')
+ * @returns Promise<boolean> - true if user has permission, false otherwise
  */
 export async function checkUserPermission(
   db: FirebaseFirestore.Firestore,
@@ -42,6 +52,7 @@ export async function checkUserPermission(
       return true;
     }
 
+    // Get user's employee document
     const employeeRef = db
       .collection(FACILITY_COLLECTION)
       .doc(facilityId)
@@ -56,10 +67,12 @@ export async function checkUserPermission(
 
     const employeeData = employeeDoc.data() as EmployeeModel;
 
+    // If user has no role assigned, they can't have specific permissions
     if (!employeeData.roleId) {
       return false;
     }
 
+    // Get user's role document
     const roleRef = db
       .collection(FACILITY_COLLECTION)
       .doc(facilityId)
@@ -74,10 +87,12 @@ export async function checkUserPermission(
 
     const roleData = roleDoc.data();
 
+    // Check if role has permissions for the specified section
     if (!roleData?.permissions || !roleData.permissions[section]) {
       return false;
     }
 
+    // Check if role has the specific permission for the section
     const sectionPermissions = roleData.permissions[section];
     return sectionPermissions.includes(permission);
 
@@ -89,6 +104,10 @@ export async function checkUserPermission(
 
 /**
  * Check if the user is an employee of the facility
+ * @param db Firestore database instance
+ * @param facilityId ID of the facility
+ * @param userId ID of the user to check
+ * @returns Promise<boolean> - true if user is facility employee, false otherwise
  */
 export async function isFacilityEmployee(
   db: FirebaseFirestore.Firestore,

--- a/firestore.rules
+++ b/firestore.rules
@@ -13,8 +13,7 @@ service cloud.firestore {
 
     function isFacilityAdmin(request, facilityId) {
       return isAuth(request) &&
-      exists(/databases/$(database)/documents/facilities/$(facilityId)/employees/$(request.auth.uid)) &&
-      get(/databases/$(database)/documents/facilities/$(facilityId)/employees/$(request.auth.uid)).data.isAdmin == true;
+      request.auth.uid in get(/databases/$(database)/documents/facilities/$(facilityId)).data.admins;
     }
 
     function isFacilityEmployee(request, facilityId) {

--- a/libs/models/src/facility/interfaces/employee-requests.model.ts
+++ b/libs/models/src/facility/interfaces/employee-requests.model.ts
@@ -1,5 +1,3 @@
-import { Role } from '../../user/constants';
-
 /**
  * Request payload for creating an employee
  * Used in createEmployee cloud function
@@ -9,7 +7,7 @@ export interface CreateEmployeeRequest {
   name: string;
   roleId: string;
   facilityId: string;
-  userType: Role;
+  isAdmin: boolean;
 }
 
 /**

--- a/libs/models/src/facility/interfaces/employee.model.ts
+++ b/libs/models/src/facility/interfaces/employee.model.ts
@@ -9,7 +9,6 @@ export interface EmployeeModel {
   uid: string;
   joined: Timestamp;
   roleId: string | null;
-  isAdmin: boolean;
   isActive: boolean;
   profile: ProfileModel;
 }

--- a/libs/models/src/facility/interfaces/facility.model.ts
+++ b/libs/models/src/facility/interfaces/facility.model.ts
@@ -10,4 +10,5 @@ export interface FacilityModel {
   name: string;
   logo: string | null;
   logoIcon: string | null;
+  admins: string[];
 }

--- a/libs/models/src/user/constants/role.constants.ts
+++ b/libs/models/src/user/constants/role.constants.ts
@@ -1,6 +1,5 @@
 export enum Role {
   SUPER_ADMIN = 'super_admin',
-  ADMIN = 'admin',
   EMPLOYEE = 'employee',
   USER = 'user',
 }


### PR DESCRIPTION
## Summary

Fixes #20

Replaces the global `Role.ADMIN` custom claim with a per-facility `admins: string[]` array on the facility document. This prevents a facility admin from having unintended full access to other facilities.

## Changes

### Models
- Removed `Role.ADMIN` from enum (only `SUPER_ADMIN`, `EMPLOYEE`, `USER` remain)
- Added `admins: string[]` to `FacilityModel`
- Removed `isAdmin` from `EmployeeModel`
- Updated `CreateEmployeeRequest`: replaced `userType: Role` with `isAdmin: boolean`

### Firestore Rules
- `isFacilityAdmin()` now reads `facility.admins` array (1 Firestore read instead of 2)

### Cloud Functions (6 files)
- `checkUserPermission()` now internally checks `facility.admins.includes(userId)`
- New `isFacilityAdminCheck()` utility function
- All functions (`create-employee`, `create-client`, `create-subscription`, `create-facility`, `setup-admin-structure`, `create-user`) updated
- Employees always get `Role.EMPLOYEE` custom claim
- Admin status managed via `FieldValue.arrayUnion()` on facility doc

### Frontend (4 files)
- `AuthContext`: removed `isAdmin` state (no longer derived from custom claims)
- `permissions.store`: checks `facility.admins.includes(uid)` instead of `employee.isAdmin`
- `protected-layout`: derives `isSuperAdmin` from claims, admin from facility data
- `employees-create`: replaced admin/employee type selector with admin checkbox

## Verification
- ✅ `admin-react` typecheck passes
- ✅ `functions` typecheck passes
- ✅ No remaining references to `Role.ADMIN` or `employee.isAdmin`